### PR TITLE
test: Sincronizar nomenclaturas E2E com BDD (Listar Editais)

### DIFF
--- a/tests/e2e/listar_editais.spec.ts
+++ b/tests/e2e/listar_editais.spec.ts
@@ -5,7 +5,7 @@ test.describe('Portal de Editais - Listagem', () => {
         await page.goto('./');
     });
 
-    test('Deve exibir a lista de editais em aberto', async ({ page }) => {
+    test('Visualizar editais em aberto', async ({ page }) => {
         const cards = page.locator('[data-testid="edital-card"]');
         await expect(cards).not.toHaveCount(0);
 
@@ -15,7 +15,7 @@ test.describe('Portal de Editais - Listagem', () => {
         await expect(firstCard.locator('[data-testid="edital-status"]')).toContainText('aberto', { ignoreCase: true });
     });
 
-    test('Deve navegar para os detalhes do edital', async ({ page }) => {
+    test('Detalhes do edital', async ({ page }) => {
         const firstTitle = page.locator('[data-testid="edital-titulo"] a').first();
         const titleText = await firstTitle.innerText();
 
@@ -25,7 +25,7 @@ test.describe('Portal de Editais - Listagem', () => {
         await expect(page.locator('h1')).toContainText(titleText.trim());
     });
 
-    test('Deve filtrar editais por busca de texto e refletir na URL', async ({ page }) => {
+    test('Buscar edital por palavra-chave', async ({ page }) => {
         const searchInput = page.locator('#search-input');
 
         // Digitar um termo que provavelmente existe (ex: FAPES)


### PR DESCRIPTION
Sincroniza os nomes dos testes E2E do \`listar_editais.spec.ts\` com os descritivos dos cenários em \`listar_editais.feature\` para reforçar a rastreabilidade entre BDD e testes de acordo com as regras do agente estabelecidas em AGENTS.MD.

Resolução da task #42.