### PR TITLE
docs: Atualiza e indexa a Documentação Primária e Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ npx playwright test
 
 - [Arquitetura](docs/architecture.md)
 - [Backlog do Projeto](docs/backlog.md)
-- [Funcionalidades (Features)](docs/features/)
+- [Funcionalidades e Features](docs/funcionalidades.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# 📚 Documentação do Portal de Editais
+
+Bem-vindo ao diretório central de documentação oficial do Portal de Editais. Este espaço é dedicado a manter o conhecimento do projeto organizado, acessível e atualizado para desenvolvedores, arquitetos e stakeholders.
+
+## 🗂️ Índice de Documentos
+
+Aqui você encontra a descrição do que cada arquivo e pasta base neste diretório faz:
+
+*   📘 **[Arquitetura do Sistema (`architecture.md`)](./architecture.md)**
+    *   **Descrição:** Detalha as decisões de design (ADRs), a stack tecnológica utilizada (Astro, TailwindCSS v4, etc) e define como a renderização SSG e estrutura de dados JSON funcionam na prática. Ideal para novos desenvolvedores entenderem o "como" e "porquê" debaixo dos panos.
+*   📋 **[Backlog do Projeto (`backlog.md`)](./backlog.md)**
+    *   **Descrição:** Uma visão viva das prioridades (User Stories e Tasks), seu mapeamento com as issues reais do GitHub, divididos em **Épicos**. Mostra o que já foi entregue e qual o roadmap de futuro do projeto.
+*   ✨ **[Índice de Funcionalidades (`funcionalidades.md`)](./funcionalidades.md)**
+    *   **Descrição:** Catálogo de todas as features visuais, de filtro, busca e comportamentais disponíveis no portal para os usuários finais, referenciadas nativamente às suas User Stories originais (ex: US9, US10).
+*   🧪 **[Testes (BDD) (`features/`)](./features/)**
+    *   **Descrição:** Diretório em que as especificações "Behavior-Driven Development" (BDD) são guardadas usando a linguagem Gherkin (`.feature`). Servem tanto de documentação de regras de negócio em português claro, quanto como guia estrito para a implementação dos testes de Interface e Integração no (Playwright).
+
+---
+> **Regra de Manutenção:** Ao projetar ou codificar novos escopos, este repertório documental deve crescer sincronamente como "Documentação Viva". Qualquer entrega de Pull Request em features ou mudanças de modelo deve atualizar no processo os documentos impactados aqui (Ex: Ao criar uma US, o BDD em `features/` precisa ser mapeado também).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ O Portal de Editais é um site estático (SSG - Static Site Generation) constru�
 ### Infraestrutura
 - **Build**: Estático (SSG).
 - **Deploy**: GitHub Pages.
-- **Busca**: Pagefind (estática, indexada no momento do build).
+- **Busca e Filtros**: Filtragem instantânea híbrida (Client-side JS + atributos DOM) sincronizada com Query Params da URL. Evita requisições de servidor e bibliotecas pesadas de terceiros.
 
 ## 📂 Estrutura de Diretórios
 

--- a/docs/funcionalidades.md
+++ b/docs/funcionalidades.md
@@ -1,0 +1,29 @@
+# Funcionalidades do Portal de Editais (Features)
+
+Este documento centraliza e descreve todas as funcionalidades (User Stories) implementadas no Portal de Editais, fornecendo um guia rápido sobre as capacidades do sistema.
+
+## 🔍 Busca e Filtragem
+
+*   **Busca Livre Integrada (US9)**: Pesquisa instantânea no lado do cliente por palavras-chave (título, descrição, instituição), combinada com filtros de categoria e status. Os resultados são atualizados em tempo real na interface sem necessidade de recarregar a página.
+*   **Filtros de Categoria (US2)**: Permite refinar a lista de oportunidades selecionando categorias temáticas específicas (ex: Pesquisa, Extensão, Inovação, Bolsas).
+*   **Filtros de Status (US8)**: Exibição segmentada de editais baseada no seu período de vigência (Abertos vs. Encerrados), facilitando a localização de oportunidades ativas.
+*   **Sincronização com URL (US8/US9)**: Todos os filtros (categoria, status e texto de busca) são automaticamente refletidos nos parâmetros da URL (ex: `?categoria=pesquisa&q=fapes`), permitindo o compartilhamento de buscas específicas.
+
+## 🗂️ Navegação e Organização
+
+*   **Página Inicial Focada**: A listagem primária (`/`) exibe por padrão apenas os editais que possuem o status `"aberto"`, priorizando as oportunidades que realmente importam.
+*   **Catálogo por Categoria (US10)**: Nova visão (`/categorias`) que agrupa hierarquicamente todos os editais (abertos e encerrados) pelas suas respectivas categorias. Dentro de cada bloco, os editais são ordenados alfabeticamente (A-Z) para facilitar a leitura sistemática.
+*   **Página Institucional "Sobre" (US11)**: Seção dedicada para explicar a missão do Portal de Editais, como ele consolida os dados de fomento e seu impacto na transparência e pesquisa no estado.
+
+## 📄 Detalhamento de Oportunidades
+
+*   **Páginas de Edital Dinâmicas (US6)**: Cada edital possui uma página dedicada (slug gerado automaticamente) contendo todas as informações relevantes lidas diretamente de um arquivo JSON padronizado.
+*   **Apresentação Clara de Metadados (US7)**: O Layout do documento exibe claramente dados críticos como o **Órgão de Fomento**, **Valor Financiado** e o **Prazo de Submissão** em formato amigável e focado na conversão (Inscrição).
+
+## ♿ Acessibilidade e Estilo
+
+*   **Acessibilidade Nativa (US4/US5)**: Suporte profundo a padrões WCAG. O usuário possui uma "Toolbar de Acessibilidade" discreta que permite a inversão de cores (Alto Contraste) e ajuste de tamanho das fontes (Escalonamento Dinâmico).
+*   **Dark Mode Nativo (US3)**: Alternância nativa e manual entre modo claro (Light Mode) e modo escuro (Dark Mode) baseada em Tailwind v4 e preservada localmente no navegador (`localStorage`), sem "Flashes" indesejados ao carregar a página.
+
+---
+> **Nota de Arquitetura**: Todas as funcionalidades são pensadas priorizando uma abordagem **estática** (SSG) via Astro e TailwindCSS, resultando em carregamentos sub-segundo, economia de banda e facilidade de deploy serverless (como o GitHub Pages).


### PR DESCRIPTION
Atualizações na Documentação Técnica

- Adicionado o arquivo `docs/funcionalidades.md` compilando todas as features e conectando-as num único documento didático.
- O `README.md` raiz foi atualizado apontando para essa nova base de conhecimento.
- Removido referência arcaica ao `Pagefind` do `docs/architecture.md`.
- E em resposta ao Code Review, foi inserido o arquivo indexador e guia `docs/README.md` compilando para que qualquer pessoa compreenda a função de cada sub-documento presente dentro dessa pasta central.